### PR TITLE
PCC-187: added alternative confirmation page

### DIFF
--- a/api/v1/.htaccess
+++ b/api/v1/.htaccess
@@ -1,5 +1,6 @@
 <IfModule mod_rewrite.c>
 	RewriteEngine On
+	RewriteRule ^confirm/([0-9]+)$ /index.php?id_cart=$1&fc=module&module=powatag&controller=confirmation2 [L]
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule (.*)$ PowaTagAPIHandle.php?request=$1 [QSA,NC,L]

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>powatag</name>
 	<displayName><![CDATA[PowaTag]]></displayName>
-	<version><![CDATA[1.0.3]]></version>
+	<version><![CDATA[1.0.4]]></version>
 	<description><![CDATA[PowaTag, the one touch payment solution that increases your online &amp;amp; mobile conversions]]></description>
 	<author><![CDATA[202-ecommerce]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/controllers/front/confirmation2.php
+++ b/controllers/front/confirmation2.php
@@ -1,0 +1,64 @@
+<?php
+/**
+* 2007-2015 PrestaShop 
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Open Software License (OSL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/osl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2014 PrestaShop SA
+*  @version  Release: $Revision: 7776 $
+*  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * Link to access the controller : $link->getModuleLink('powatag', 'confirmation')
+ */
+class PowatagConfirmation2ModuleFrontController extends ModuleFrontController
+{
+	public function __construct()
+	{
+		$this->display_column_left = false;
+		$this->display_column_right = false;
+		parent::__construct();
+		$this->context = Context::getContext();
+
+	}
+
+	public function postProcess()
+	{
+		parent::postProcess();
+	}
+
+	public function init()
+	{
+		parent::init();
+	}
+
+	public function initContent()
+	{
+		parent::initContent();
+		
+		$this->setTemplate('confirmation2.tpl');
+	}
+
+	public function setMedia()
+	{
+		parent::setMedia();
+		$this->addCSS(__PS_BASE_URI__.'modules/powatag/css/confirmation.css');
+	}
+}

--- a/powatag.php
+++ b/powatag.php
@@ -47,7 +47,7 @@ class PowaTag extends PaymentModule {
 	{
 		$this->name = 'powatag';
 		$this->tab = 'mobile';
-		$this->version = '1.0.3';
+		$this->version = '1.0.4';
 		$this->author = '202-ecommerce';
 
 

--- a/views/templates/front/confirmation2.tpl
+++ b/views/templates/front/confirmation2.tpl
@@ -1,0 +1,30 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<h2>{l s='Order confirmed' mod='powatag'}</h2>
+
+<p>
+{l s='An order has been successfully created.' mod='powatag'}
+</p>


### PR DESCRIPTION
I added alternative confirmation page that displays just "Thank you for your order" text without any order or customer details. The motivation was that our core system in current version cannot pass URL of confirmation page that is returned from create order operation and current confirmation page doesn't work. This solution was created as workaround and is not planed to be used with next release of our core system.
